### PR TITLE
Use relative paths for the tests; fixes an error on Linux.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -162,8 +162,8 @@ model {
     testSuites {
         ntcoreTestingBaseTest {
             sources {
-                cpp.source.srcDir '/src/test/native/cpp'
-                cpp.exportedHeaders.srcDir '/src/test/native/include'
+                cpp.source.srcDir 'src/test/native/cpp'
+                cpp.exportedHeaders.srcDir 'src/test/native/include'
             }
         }
     }


### PR DESCRIPTION
This is a minor fix that helped my build progress.